### PR TITLE
Revert "task 9: fixed typo changed from 2022 to 2021"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2021 XYZ, Inc._
+_© 2022 XYZ, Inc._


### PR DESCRIPTION
This reverts commit 5a31f0d630c1bb9e0da045dd62c7a7db04f9f44c.